### PR TITLE
docs: deprecation notice + phoonnx migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,73 @@
-## Description
+> **This repository is archived. No further updates will be made.**
+>
+> Piper support has been absorbed into [phoonnx](https://github.com/TigreGotico/phoonnx), a unified ONNX TTS plugin that supports Piper, Matcha, GlowTTS, MMS, and more. Migrate using the guide below.
 
-[OpenVoiceOS (OVOS)](https://openvoiceos.org) TTS plugin for [piper](https://github.com/rhasspy/piper)
-
--------
-
-> **WARNING**: this plugin is no longer maintained, you should move to [phoonnx](https://github.com/TigreGotico/phoonnx), a generic VITS inference plugin that supports piper, mimic3, coqui, MMS...
-
--------
+# ovos-tts-plugin-piper → phoonnx migration
 
 ## Install
 
-`pip install ovos-tts-plugin-piper`
-
-> NOTE: `espeak-ng` must be available in your base OS (install via your distro package manager)
-
-For Arabic Piper models, you may optionally install `piper-phonemize` (or `piper-phonemize-fix`) to enable the tashkeel diacritizer.
-
-## Configuration
-
-voice models are automatically downloaded from https://huggingface.co/rhasspy/piper-voices into `~/.local/share/piper_tts`
-
-full list of voices can be found [here](https://huggingface.co/rhasspy/piper-voices/blob/main/voices.json)
-
-you can also pass a short name alias without lang code, eg `"alan-low"` instead of `"en_GB-alan-low"`
-
-```json
-  "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "voice": "alan-low"
-    }
-  }
-```
-if no voice is set it will be auto selected based on language
-
-you can also define a local path for your own model
-
-```json
-  "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "model": "/path/to/model.onnx",
-      "model_config": "/path/to/model.onnx.json"
-    }
-  }
+```bash
+pip install phoonnx
 ```
 
-or a remote url
+`espeak-ng` must be available in your base OS (install via your distro package manager) — same requirement as before.
+
+## Configuration mapping
+
+Replace the plugin module and key. Voice IDs use the `piper/<lang_code>-<name>` format:
+
+**Before:**
+```json
+"tts": {
+  "module": "ovos-tts-plugin-piper",
+  "ovos-tts-plugin-piper": {
+    "voice": "alan-low"
+  }
+}
+```
+
+**After:**
+```json
+"tts": {
+  "module": "phoonnx",
+  "phoonnx": {
+    "voice": "piper/en_GB-alan-low"
+  }
+}
+```
+
+### Local model path
 
 ```json
-  "tts": {
-    "module": "ovos-tts-plugin-piper",
-    "ovos-tts-plugin-piper": {
-      "model": "https://huggingface.co/poisson-fish/piper-vasco/resolve/main/onnx/vasco.onnx",
-      "model_config": "https://huggingface.co/poisson-fish/piper-vasco/resolve/main/onnx/vasco.onnx.json"
-    }
+"tts": {
+  "module": "phoonnx",
+  "phoonnx": {
+    "model": "/path/to/model.onnx",
+    "model_config": "/path/to/model.onnx.json"
   }
+}
 ```
+
+### Remote URL
+
+```json
+"tts": {
+  "module": "phoonnx",
+  "phoonnx": {
+    "model": "https://huggingface.co/poisson-fish/piper-vasco/resolve/main/onnx/vasco.onnx",
+    "model_config": "https://huggingface.co/poisson-fish/piper-vasco/resolve/main/onnx/vasco.onnx.json"
+  }
+}
+```
+
+### Auto-select by language
+
+Leave `voice` unset and phoonnx selects the best available voice for the configured language, including all Piper voices.
+
+## Voice catalogue
+
+All available Piper voices (and every other supported voice) are listed in [VOICES.md](https://github.com/TigreGotico/phoonnx/blob/dev/VOICES.md) — that is the canonical reference for voice IDs to use in your config.
+
+## Credits
+
+Original plugin by the OpenVoiceOS community. Piper TTS engine by [rhasspy](https://github.com/rhasspy/piper).


### PR DESCRIPTION
This plugin has been absorbed into [phoonnx](https://github.com/TigreGotico/phoonnx). Replaces the README with a deprecation notice and full migration guide with accurate voice IDs (from VOICES.md) and correct config examples. The repo will be archived after this merges.